### PR TITLE
PAGOSONLINEPPS-28105: Actualizar SDK de PayU

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.5</version>
+	<version>1.1.6</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -374,6 +374,9 @@ public abstract class PayU {
 		/** The subscription extra charges description */
 		String SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION = "subscriptionExtraChargesDescription";
 		
+		/** The subscription source reference */
+		String SOURCE_REFERENCE = "sourceReference";
+		
 	}
 
 }

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -283,6 +283,8 @@ public abstract class PayU {
 
 		/** The number of trial days. */
 		String TRIAL_DAYS = "trialDays";
+		/** The immediate payment flag. */
+		String IMMEDIATE_PAYMENT = "immediatePayment";
 		/** The quantity to purchase. */
 		String QUANTITY = "quantity";
 
@@ -349,7 +351,29 @@ public abstract class PayU {
 		
 		/** The EXTRA 3 transaction extra parameter. */
 		String EXTRA3 = "extra3";
-
+		
+		/** Delivery Address Fields */
+		
+		/** Delivery Address1 field */
+		String DELIVERY_ADDRESS_1 = "line1";
+		/** Delivery Address2 field */
+		String DELIVERY_ADDRESS_2= "line2";
+		/** Delivery Address3 field */
+		String DELIVERY_ADDRESS_3 = "line3";
+		/** Delivery city field */
+		String DELIVERY_CITY = "city";
+		/** Delivery state field */
+		String DELIVERY_STATE = "state";
+		/** Delivery country field */
+		String DELIVERY_COUNTRY = "country";
+		/** Delivery postal code field */
+		String DELIVERY_POSTAL_CODE = "postalCode";
+		/** Delivery phone field */
+		String DELIVERY_PHONE = "phone";
+		
+		/** The subscription extra charges description */
+		String SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION = "subscriptionExtraChargesDescription";
+		
 	}
 
 }

--- a/src/main/java/com/payu/sdk/PayUSubscription.java
+++ b/src/main/java/com/payu/sdk/PayUSubscription.java
@@ -89,7 +89,17 @@ public final class PayUSubscription extends PayU {
 					PayU.PARAMETERS.ACCOUNT_ID};
 			PaymentPlanRequestUtil.validateParameters(parameters, params);
 		}
+		
+		// Subscription extra charges parameters
+		if (parameters.containsKey(PayU.PARAMETERS.SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION)) {
+			params = new String[] { 
+					PayU.PARAMETERS.SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION, 
+					PayU.PARAMETERS.ITEM_VALUE,
+					PayU.PARAMETERS.CURRENCY };
 
+			PaymentPlanRequestUtil.validateParameters(parameters, params);
+		}
+		
 		// Customer parameters
 		if (parameters.containsKey(PayU.PARAMETERS.CUSTOMER_ID)) {
 

--- a/src/main/java/com/payu/sdk/constants/Resources.java
+++ b/src/main/java/com/payu/sdk/constants/Resources.java
@@ -59,11 +59,16 @@ public interface Resources {
 	 * API Version 4.0
 	 */
 	String V4_0 = "4.0";
+	
+	/**
+	 * API Version 4.9
+	 */
+	String V4_9 = "v4.9";
 
 	/**
 	 * Payment Plan Current Version
 	 */
-	String PAYMENT_PLAN_VERSION = V4_3;
+	String PAYMENT_PLAN_VERSION = V4_9;
 
 	/**
 	 * Default API Current Version

--- a/src/main/java/com/payu/sdk/model/request/Environment.java
+++ b/src/main/java/com/payu/sdk/model/request/Environment.java
@@ -35,8 +35,8 @@ public enum Environment {
 	/**
 	 * Default url for payments and reports requests
 	 */
-	API_URL("https://dev.payments-api.payulatam.com:18085/payments-api/",
-			"https://dev.payments-api.payulatam.com:18085/reports-api/");
+	API_URL("https://api.payulatam.com/payments-api/",
+			"https://api.payulatam.com/reports-api/");
 
 	/** Payments request's url */
 	private String paymentsUrl;

--- a/src/main/java/com/payu/sdk/model/request/Environment.java
+++ b/src/main/java/com/payu/sdk/model/request/Environment.java
@@ -35,8 +35,8 @@ public enum Environment {
 	/**
 	 * Default url for payments and reports requests
 	 */
-	API_URL("https://api.payulatam.com/payments-api/",
-			"https://api.payulatam.com/reports-api/");
+	API_URL("https://dev.payments-api.payulatam.com:18085/payments-api/",
+			"https://dev.payments-api.payulatam.com:18085/reports-api/");
 
 	/** Payments request's url */
 	private String paymentsUrl;

--- a/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
+++ b/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
@@ -24,6 +24,7 @@
 package com.payu.sdk.paymentplan.model;
 
 import java.util.Date;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -37,7 +38,6 @@ import com.payu.sdk.exceptions.PayUException;
 import com.payu.sdk.model.Address;
 import com.payu.sdk.model.request.Request;
 import com.payu.sdk.utils.JaxbUtil;
-import java.util.List;
 
 /**
  * Represents a Subscription (Recurrent Payment) in the PayU SDK.
@@ -48,9 +48,9 @@ import java.util.List;
  */
 @XmlRootElement(name = "subscription")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "id", "trialDays", "immediatePayment", "quantity", "installments",
-		"currentPeriodStart", "currentPeriodEnd", "customer", "plan",
-		"creditCardToken", "bankAccountId","termsAndConditionsAcepted", "deliveryAddress", "recurringBillItems" })
+@XmlType(propOrder = { "id", "trialDays", "quantity", "installments", "currentPeriodStart", "currentPeriodEnd", "customer",
+		"plan", "creditCardToken", "bankAccountId", "termsAndConditionsAcepted", "immediatePayment", "deliveryAddress",
+		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2" })
 public class Subscription extends Request {
 
 	/**
@@ -129,9 +129,29 @@ public class Subscription extends Request {
 	private Address deliveryAddress;
 	
 	/**
+	 * The subscription notify url
+	 */
+	private String notifyUrl;
+	
+	/**
+	 * The subscription source reference
+	 */
+	private String sourceReference;
+	
+	/**
 	 * The extra charges of a subscription
 	 */
 	private List<RecurringBillItem> recurringBillItems;
+	
+	/**
+	 * The extra1 field
+	 */
+	private String extra1;
+	
+	/**
+	 * The extra2 field
+	 */
+	private String extra2;
 	
 	// -------------------------------------------------------
 	// GETTERS AND SETTERS
@@ -265,6 +285,26 @@ public class Subscription extends Request {
 	}
 	
 	/**
+	 * Returns the subscription notify url
+	 * 
+	 * @return the notifyUrl
+	 */
+	public String getNotifyUrl() {
+	
+		return notifyUrl;
+	}
+
+	/**
+	 * Returns the subscription source reference
+	 * 
+	 * @return the sourceReference
+	 */
+	public String getSourceReference() {
+		
+		return sourceReference;
+	}
+	
+	/**
 	 * Returns the subscription recurring bill items
 	 * 
 	 * @return the recurringBillItems
@@ -272,6 +312,26 @@ public class Subscription extends Request {
 	public List<RecurringBillItem> getRecurringBillItems() {
 		
 		return recurringBillItems;
+	}
+	
+	/**
+	 * Returns the subscription extra1 field
+	 * 
+	 * @return the extra1
+	 */
+	public String getExtra1() {
+
+		return extra1;
+	}
+
+	/**
+	 * Returns the subscription's extra2 field
+	 * 
+	 * @return the extra2
+	 */
+	public String getExtra2() {
+
+		return extra2;
 	}
 	
 	/**
@@ -396,7 +456,7 @@ public class Subscription extends Request {
 
 		this.immediatePayment = immediatePayment;
 	}
-	
+
 	/**
 	 * Sets the subscription deliveryAddres
 	 * 
@@ -404,10 +464,32 @@ public class Subscription extends Request {
 	 *            the delivery address
 	 */
 	public void setDeliveryAddress(Address deliveryAddress) {
-		
+
 		this.deliveryAddress = deliveryAddress;
 	}
-	
+
+	/**
+	 * Sets the subscription notify url
+	 * 
+	 * @param notifyUrl
+	 *            the notifyUrl to set
+	 */
+	public void setNotifyUrl(String notifyUrl) {
+
+		this.notifyUrl = notifyUrl;
+	}
+
+	/**
+	 * Sets the subscription source reference
+	 * 
+	 * @param sourceReference
+	 *            the source reference to set
+	 */
+	public void setSourceReference(String sourceReference) {
+
+		this.sourceReference = sourceReference;
+	}
+
 	/**
 	 * Sets the suscription recurring bill items
 	 * 
@@ -417,6 +499,28 @@ public class Subscription extends Request {
 	public void setRecurringBillItems(List<RecurringBillItem> recurringBillItems) {
 
 		this.recurringBillItems = recurringBillItems;
+	}
+
+	/**
+	 * Sets the extra1 field
+	 * 
+	 * @param extra1
+	 *            the extra1 to set
+	 */
+	public void setExtra1(String extra1) {
+
+		this.extra1 = extra1;
+	}
+
+	/**
+	 * Sets the extra2 field
+	 * 
+	 * @param extra2
+	 *            the extra2 to set
+	 */
+	public void setExtra2(String extra2) {
+
+		this.extra2 = extra2;
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
+++ b/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
@@ -34,8 +34,10 @@ import javax.xml.bind.annotation.XmlType;
 import com.payu.sdk.constants.Resources;
 import com.payu.sdk.constants.Resources.RequestMethod;
 import com.payu.sdk.exceptions.PayUException;
+import com.payu.sdk.model.Address;
 import com.payu.sdk.model.request.Request;
 import com.payu.sdk.utils.JaxbUtil;
+import java.util.List;
 
 /**
  * Represents a Subscription (Recurrent Payment) in the PayU SDK.
@@ -46,9 +48,9 @@ import com.payu.sdk.utils.JaxbUtil;
  */
 @XmlRootElement(name = "subscription")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "id", "trialDays", "quantity", "installments",
+@XmlType(propOrder = { "id", "trialDays", "immediatePayment", "quantity", "installments",
 		"currentPeriodStart", "currentPeriodEnd", "customer", "plan",
-		"creditCardToken", "bankAccountId","termsAndConditionsAcepted" })
+		"creditCardToken", "bankAccountId","termsAndConditionsAcepted", "deliveryAddress", "recurringBillItems" })
 public class Subscription extends Request {
 
 	/**
@@ -110,13 +112,27 @@ public class Subscription extends Request {
 	 * Bank account identifier to modify for the subscription
 	 */
 	private String  bankAccountId;
-
-
-	/*
+	
+	/**
 	 *  If the client accepted the terms and conditions document.
 	 */
 	private Boolean termsAndConditionsAcepted;
-
+	
+	/**
+	 * Allows to process an immediate payment when the subscription is created
+	 */
+	private Boolean immediatePayment;
+	
+	/**
+	 * Subscription delivery address
+	 */
+	private Address deliveryAddress;
+	
+	/**
+	 * The extra charges of a subscription
+	 */
+	private List<RecurringBillItem> recurringBillItems;
+	
 	// -------------------------------------------------------
 	// GETTERS AND SETTERS
 	// -------------------------------------------------------
@@ -227,7 +243,37 @@ public class Subscription extends Request {
 
 		return bankAccountId;
 	}
+	
+	/**
+	 * Returns a flag to indicate an inmmediate payment
+	 * 
+	 * @return the immediate payment flag
+	 */
+	public Boolean getImmediatePayment() {
 
+		return immediatePayment;
+	}
+	
+	/**
+	 * Returns the subscription delivery address
+	 * 
+	 * @return the object delivery address
+	 */
+	public Address getDeliveryAddress() {
+		
+		return deliveryAddress;
+	}
+	
+	/**
+	 * Returns the subscription recurring bill items
+	 * 
+	 * @return the recurringBillItems
+	 */
+	public List<RecurringBillItem> getRecurringBillItems() {
+		
+		return recurringBillItems;
+	}
+	
 	/**
 	 * Sets the subscription identifier
 	 *
@@ -339,8 +385,40 @@ public class Subscription extends Request {
 
 		this.bankAccountId = bankAccountId;
 	}
+	
+	/**
+	 * Sets the inmmediate payment
+	 * 
+	 * @param immediatePayment
+	 *            the immediate payment flag
+	 */
+	public void setImmediatePayment(Boolean immediatePayment) {
 
+		this.immediatePayment = immediatePayment;
+	}
+	
+	/**
+	 * Sets the subscription deliveryAddres
+	 * 
+	 * @param deliveryAddress
+	 *            the delivery address
+	 */
+	public void setDeliveryAddress(Address deliveryAddress) {
+		
+		this.deliveryAddress = deliveryAddress;
+	}
+	
+	/**
+	 * Sets the suscription recurring bill items
+	 * 
+	 * @param recurringBillItems
+	 *            the recurringBillItems to set
+	 */
+	public void setRecurringBillItems(List<RecurringBillItem> recurringBillItems) {
 
+		this.recurringBillItems = recurringBillItems;
+	}
+	
 	/* (non-Javadoc)
 	 * @see com.payu.sdk.model.request.Request#getBaseRequestUrl(java.lang.String, com.payu.sdk.constants.Resources.RequestMethod)
 	 */

--- a/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
@@ -25,6 +25,8 @@ package com.payu.sdk.utils;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,8 +53,8 @@ import com.payu.sdk.payments.model.CustomerListRequest;
 import com.payu.sdk.payments.model.PaymentPlanCreditCardListRequest;
 import com.payu.sdk.payments.model.RecurringBillItemListRequest;
 import com.payu.sdk.payments.model.RecurringBillListRequest;
-import com.payu.sdk.payments.model.SubscriptionsListRequest;
 import com.payu.sdk.payments.model.SubscriptionPlanListRequest;
+import com.payu.sdk.payments.model.SubscriptionsListRequest;
 
 /**
  * Utility for payment plan requests in the PayU SDK.
@@ -561,7 +563,7 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 
 		return request;
 	}
-
+	
 	/**
 	 * Builds a subscription request
 	 *
@@ -576,6 +578,8 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		// Subscription basic parameters
 		Integer trialDays = getIntegerParameter(parameters,
 				PayU.PARAMETERS.TRIAL_DAYS);
+		Boolean immediatePayment = getBooleanParameter(parameters,
+				PayU.PARAMETERS.IMMEDIATE_PAYMENT);
 		Integer quantity = getIntegerParameter(parameters,
 				PayU.PARAMETERS.QUANTITY);
 		Integer installments = getIntegerParameter(parameters,
@@ -585,6 +589,8 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 				PayU.PARAMETERS.SUBSCRIPTION_ID);
 		Boolean termsAndConditionsAcepted=getBooleanParameter(parameters,
 				PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED);
+		
+		List<RecurringBillItem> recurringBillItems = buildRecurringBillItemList(parameters);
 
 		// Plan parameter
 		SubscriptionPlan plan = buildSubscriptionPlanRequest(parameters);
@@ -614,26 +620,65 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 			}
 			customer.addBankAccount(bankAccount);
 		}
-
-
+		
+		// Delivery address parameters
+		Address deliveryAddress = new Address();
+		deliveryAddress.setLine1(getParameter(parameters, PayU.PARAMETERS.DELIVERY_ADDRESS_1));
+		deliveryAddress.setLine2(getParameter(parameters, PayU.PARAMETERS.DELIVERY_ADDRESS_2));
+		deliveryAddress.setLine3(getParameter(parameters, PayU.PARAMETERS.DELIVERY_ADDRESS_3));
+		deliveryAddress.setCity(getParameter(parameters, PayU.PARAMETERS.DELIVERY_CITY));
+		deliveryAddress.setState(getParameter(parameters, PayU.PARAMETERS.DELIVERY_STATE));
+		deliveryAddress.setCountry(getParameter(parameters, PayU.PARAMETERS.DELIVERY_COUNTRY));
+		deliveryAddress.setPostalCode(getParameter(parameters, PayU.PARAMETERS.DELIVERY_POSTAL_CODE));
+		deliveryAddress.setPhone(getParameter(parameters, PayU.PARAMETERS.DELIVERY_PHONE));
+		
 		// Subscription basic parameters
 		Subscription request = new Subscription();
 		setAuthenticationCredentials(parameters, request);
 
 		request.setTrialDays(trialDays);
+		request.setImmediatePayment(immediatePayment);
 		request.setQuantity(quantity);
 		request.setInstallments(installments);
 		request.setTermsAndConditionsAcepted(termsAndConditionsAcepted);
+		request.setDeliveryAddress(deliveryAddress);
 
 		// Subscription complex parameters (customer and plan)
 		request.setPlan(plan);
 		request.setCustomer(customer);
-
 		request.setId(subscriptionId);
+		request.setRecurringBillItems(recurringBillItems);
 
 		return request;
 	}
-
+	
+	/**
+	 * Builds a recurring billing item request without authentication
+	 * 
+	 * @param parameters
+	 *            The parameters to be sent to the server
+	 * @return List<RecurringBillItem> The RecurringBillItems list
+	 * @throws InvalidParametersException
+	 */
+	private static List<RecurringBillItem> buildRecurringBillItemList(Map<String, String> parameters)
+			throws InvalidParametersException {
+		
+		if (parameters.containsKey(PayU.PARAMETERS.SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION)) {
+			String description = getParameter(parameters, PayU.PARAMETERS.SUBSCRIPTION_EXTRA_CHARGES_DESCRIPTION);
+			BigDecimal value = getBigDecimalParameter(parameters, PayU.PARAMETERS.ITEM_VALUE);
+			BigDecimal taxValue = getBigDecimalParameter(parameters, PayU.PARAMETERS.ITEM_TAX);
+			BigDecimal taxReturnBase = getBigDecimalParameter(parameters, PayU.PARAMETERS.ITEM_TAX_RETURN_BASE);
+			Currency currency = getEnumValueParameter(Currency.class, parameters, PayU.PARAMETERS.CURRENCY);
+			RecurringBillItem recurringBillItem = new RecurringBillItem();
+			recurringBillItem.setDescription(description);
+			List<AdditionalValue> additionalValues = buildItemAdditionalValues(currency, value, taxValue, taxReturnBase);
+			recurringBillItem.setAdditionalValues(additionalValues);
+			return Arrays.asList(recurringBillItem);
+		}
+		
+		return Collections.emptyList();
+	}
+	
 	/**
 	 * Builds an update subscription request
 	 *
@@ -653,14 +698,27 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 
 		String subscriptionId = getParameter(parameters,
 				PayU.PARAMETERS.SUBSCRIPTION_ID);
-
+		
 		Subscription request = new Subscription();
+		
+		// Set the delivery address fields
+		Address deliveryAddress = new Address();
+		deliveryAddress.setLine1(getParameter(parameters,PayU.PARAMETERS.DELIVERY_ADDRESS_1));
+		deliveryAddress.setLine2(getParameter(parameters,PayU.PARAMETERS.DELIVERY_ADDRESS_2));
+		deliveryAddress.setLine3(getParameter(parameters,PayU.PARAMETERS.DELIVERY_ADDRESS_3));
+		deliveryAddress.setCity(getParameter(parameters,PayU.PARAMETERS.DELIVERY_CITY));
+		deliveryAddress.setState(getParameter(parameters,PayU.PARAMETERS.DELIVERY_STATE));
+		deliveryAddress.setCountry(getParameter(parameters,PayU.PARAMETERS.DELIVERY_COUNTRY));
+		deliveryAddress.setPostalCode(getParameter(parameters,PayU.PARAMETERS.DELIVERY_POSTAL_CODE));
+		deliveryAddress.setPhone(getParameter(parameters,PayU.PARAMETERS.DELIVERY_PHONE));
+		
 		setAuthenticationCredentials(parameters, request);
 
 		request.setUrlId(subscriptionId);
 		request.setCreditCardToken(newCreditCardToken);
 		request.setBankAccountId(newBankAccountId);
-
+		request.setDeliveryAddress(deliveryAddress);
+		
 		return request;
 
 	}

--- a/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
@@ -632,6 +632,12 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		deliveryAddress.setPostalCode(getParameter(parameters, PayU.PARAMETERS.DELIVERY_POSTAL_CODE));
 		deliveryAddress.setPhone(getParameter(parameters, PayU.PARAMETERS.DELIVERY_PHONE));
 		
+		// Subscription notifyUrl, sourceReference, extra1 and extra 2 parameters
+		String notifyUrl = getParameter(parameters, PayU.PARAMETERS.NOTIFY_URL);
+		String sourceReference = getParameter(parameters, PayU.PARAMETERS.SOURCE_REFERENCE);
+		String extra1 = getParameter(parameters, PayU.PARAMETERS.EXTRA1);
+		String extra2 = getParameter(parameters, PayU.PARAMETERS.EXTRA2);
+		
 		// Subscription basic parameters
 		Subscription request = new Subscription();
 		setAuthenticationCredentials(parameters, request);
@@ -642,12 +648,16 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		request.setInstallments(installments);
 		request.setTermsAndConditionsAcepted(termsAndConditionsAcepted);
 		request.setDeliveryAddress(deliveryAddress);
+		request.setRecurringBillItems(recurringBillItems);
+		request.setNotifyUrl(notifyUrl);
+		request.setSourceReference(sourceReference);
+		request.setExtra1(extra1);
+		request.setExtra1(extra2);
 
 		// Subscription complex parameters (customer and plan)
 		request.setPlan(plan);
 		request.setCustomer(customer);
 		request.setId(subscriptionId);
-		request.setRecurringBillItems(recurringBillItems);
 
 		return request;
 	}

--- a/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
@@ -446,6 +446,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -494,6 +506,19 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
 		parameters.put(PayU.PARAMETERS.CUSTOMER_EMAIL, "prueba@payulatam.com");
@@ -554,6 +579,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -695,6 +732,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -747,6 +796,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -822,6 +883,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -869,6 +942,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -931,6 +1016,19 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
 		// Plan parameters
@@ -987,6 +1085,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1039,6 +1149,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1097,6 +1219,18 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_DESCRIPTION, "Basic Plan");
@@ -1161,6 +1295,19 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
 		// Plan parameters
@@ -1314,6 +1461,19 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
 		// Plan parameters

--- a/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
@@ -442,6 +442,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -489,6 +490,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -549,6 +551,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -688,6 +691,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -739,6 +743,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -813,6 +818,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -859,6 +865,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -920,6 +927,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -975,6 +983,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -1026,6 +1035,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -1083,6 +1093,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -1146,6 +1157,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		parameters.put(PayU.PARAMETERS.TERMS_AND_CONDITIONS_ACEPTED, "true");
@@ -1299,6 +1311,7 @@ public class BankAccountApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 		// Customer parameters

--- a/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
@@ -1072,6 +1072,7 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
 		parameters.put(PayU.PARAMETERS.TOKEN_ID, tokenId);
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 
 		try {
@@ -1107,6 +1108,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1165,6 +1167,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1219,6 +1222,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1286,6 +1290,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1311,6 +1316,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1344,6 +1350,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1376,6 +1383,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 
@@ -1434,6 +1442,7 @@ public class PaymentPlanApiIntegrationTest {
 
 		// Subscription parameters
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
+		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
 

--- a/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
@@ -1074,6 +1074,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.QUANTITY, "5");
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		try {
 			Subscription response = PayUSubscription.create(parameters);
@@ -1111,6 +1123,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");
@@ -1170,6 +1194,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1225,6 +1261,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1293,6 +1341,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		Subscription response = PayUSubscription.create(parameters);
 
@@ -1319,6 +1379,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 
@@ -1353,6 +1425,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_CODE, planCode);
@@ -1386,6 +1470,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1445,6 +1541,18 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.IMMEDIATE_PAYMENT, "true");
 		parameters.put(PayU.PARAMETERS.INSTALLMENTS_NUMBER, "2");
 		parameters.put(PayU.PARAMETERS.TRIAL_DAYS, "2");
+		parameters.put(PayU.PARAMETERS.NOTIFY_URL, "testUrl");
+		parameters.put(PayU.PARAMETERS.SOURCE_REFERENCE, "testSourceReference");
+		parameters.put(PayU.PARAMETERS.EXTRA1, "extra1");
+		parameters.put(PayU.PARAMETERS.EXTRA2, "extra2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_1, "line1");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_2, "line2");
+		parameters.put(PayU.PARAMETERS.DELIVERY_ADDRESS_3, "line3");
+		parameters.put(PayU.PARAMETERS.DELIVERY_CITY, "Bogotá");
+		parameters.put(PayU.PARAMETERS.DELIVERY_STATE, "Cundinamarca");
+		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
+		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
+		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");


### PR DESCRIPTION
Se realizaron las siguientes modificaciones:

1. Adición de los campos inmmediatePayment, deliveryAddress, notifyUrl, sourceReference, recurringBillItems, extra1 y extra2 a la suscripción.
2. Para la creación de una suscripción, todos estos campos son opcionales.
3. Para la edición de una suscripción, solo se agrega la modificación de deliveryAddress. Este campo es opcional.
4. Se actualiza la versión del API de payments a 4.9. Esta versión del API es la que soporta los cambios mencionados anteriormente.
5. Actualización de pruebas unitarias.

**NOTA:**
- Todos estos cambios son compatibles con la versión 4.3 del API de payments.
- En el momento en que estos cambios sean aprobados, mezclados en master y el jar se encuentre en artifactory de PayU, se actualizará la versión de la dependencia del SDK en secure a 1.1.6