### PR TITLE
PAGOSONLINEPPS-28693: Nuevos campos sourceId y description para la creación de suscripciones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.6</version>
+	<version>1.1.7</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -377,6 +377,9 @@ public abstract class PayU {
 		/** The subscription source reference */
 		String SOURCE_REFERENCE = "sourceReference";
 		
+		/** The subscription ID from POL */
+		String SOURCE_ID = "sourceId";
+		
 	}
 
 }

--- a/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
+++ b/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
@@ -50,7 +50,7 @@ import com.payu.sdk.utils.JaxbUtil;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "id", "trialDays", "quantity", "installments", "currentPeriodStart", "currentPeriodEnd", "customer",
 		"plan", "creditCardToken", "bankAccountId", "termsAndConditionsAcepted", "immediatePayment", "deliveryAddress",
-		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2" })
+		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2", "sourceId", "description" })
 public class Subscription extends Request {
 
 	/**
@@ -152,6 +152,16 @@ public class Subscription extends Request {
 	 * The extra2 field
 	 */
 	private String extra2;
+	
+	/**
+	 * The susbscription ID in POL
+	 */
+	private Long sourceId;
+	
+	/**
+	 * The subscription's description / comments 
+	 */
+	private String description;
 	
 	// -------------------------------------------------------
 	// GETTERS AND SETTERS
@@ -332,6 +342,26 @@ public class Subscription extends Request {
 	public String getExtra2() {
 
 		return extra2;
+	}
+	
+	/**
+	 * Returns the source id. Represents the subscription ID in POL when subscription is migrated
+	 * 
+	 * @return the source id
+	 */
+	public Long getSourceId() {
+		
+		return sourceId; 
+	}
+	
+	/**
+	 * Returns the subscription description
+	 * 
+	 * @return the subscription description
+	 */
+	public String getDescription() {
+		
+		return description;
 	}
 	
 	/**
@@ -521,6 +551,28 @@ public class Subscription extends Request {
 	public void setExtra2(String extra2) {
 
 		this.extra2 = extra2;
+	}
+	
+	/**
+	 * Sets the source id. Represents the subscription ID in POL when subscription is migrated
+	 * 
+	 * @param sourceId
+	 *            The subscription ID in POL
+	 */
+	public void setSourceId(Long sourceId) {
+
+		this.sourceId = sourceId;
+	}
+
+	/**
+	 * Sets the subscription description
+	 * 
+	 * @param description
+	 *            The subscription description
+	 */
+	public void setDescription(String description) {
+
+		this.description = description;
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/com/payu/sdk/utils/CommonRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/CommonRequestUtil.java
@@ -208,6 +208,30 @@ public class CommonRequestUtil {
 
 		return bigDecimalValue;
 	}
+	
+	/**
+	 * Gets a long value from parameters
+	 *
+	 * @param value
+	 *            the value to convert to long
+	 * @param name
+	 *            the name of the parameter (exception purposes)
+	 * @return the long it got
+	 * @throws InvalidParametersException
+	 */
+	private static Long getLong(String value, String name)
+			throws InvalidParametersException {
+		Long longValue = null;
+		try {
+			longValue = new Long(value);
+		} catch (Exception e) {
+			throw new InvalidParametersException(String.format(
+					"The parameter [%s] isn't a valid Long value", name),
+					e);
+		}
+
+		return longValue;
+	}
 
 	/**
 	 * Gets a parameter based on it's name
@@ -346,6 +370,29 @@ public class CommonRequestUtil {
 				parameter, paramName) : null);
 
 		return bigDecimalParameter;
+	}
+	
+	/**
+	 * Gets a long parameter from the parameters map
+	 *
+	 * @param parameters
+	 *            The parameters to be sent to the server
+	 * @param paramName
+	 *            the parameter to get
+	 * @return The long parameter it got
+	 * @throws InvalidParametersException
+	 */
+	protected static Long getLongParameter(
+			Map<String, String> parameters, String paramName)
+			throws InvalidParametersException {
+		String parameter = getParameter(parameters, paramName);
+		if (parameter != null && parameter.trim().isEmpty()) {
+			parameter = null;
+		}
+		Long longParameter = (parameter != null ? getLong(parameter,
+				paramName) : null);
+
+		return longParameter;
 	}
 
 	/**

--- a/src/main/java/com/payu/sdk/utils/CommonRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/CommonRequestUtil.java
@@ -223,7 +223,7 @@ public class CommonRequestUtil {
 			throws InvalidParametersException {
 		Long longValue = null;
 		try {
-			longValue = new Long(value);
+			longValue = Long.valueOf(value);
 		} catch (Exception e) {
 			throw new InvalidParametersException(String.format(
 					"The parameter [%s] isn't a valid Long value", name),

--- a/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
@@ -638,6 +638,10 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		String extra1 = getParameter(parameters, PayU.PARAMETERS.EXTRA1);
 		String extra2 = getParameter(parameters, PayU.PARAMETERS.EXTRA2);
 		
+		// Subscription sourceId and description
+		Long sourceId = getLongParameter(parameters, PayU.PARAMETERS.SOURCE_ID);
+		String description = getParameter(parameters, PayU.PARAMETERS.DESCRIPTION);
+		
 		// Subscription basic parameters
 		Subscription request = new Subscription();
 		setAuthenticationCredentials(parameters, request);
@@ -653,6 +657,8 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		request.setSourceReference(sourceReference);
 		request.setExtra1(extra1);
 		request.setExtra1(extra2);
+		request.setSourceId(sourceId);
+		request.setDescription(description);
 
 		// Subscription complex parameters (customer and plan)
 		request.setPlan(plan);

--- a/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
@@ -458,6 +458,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -518,6 +520,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -591,6 +595,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -675,6 +681,7 @@ public class BankAccountApiIntegrationTest {
 		// Credit card parameters
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "4005580000029205");
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2025/01");
+		parameters.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parameters.put(PayU.PARAMETERS.PAYMENT_METHOD, "VISA");
 
 		parameters.put(PayU.PARAMETERS.PAYER_NAME, "Oscar R");
@@ -744,6 +751,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -808,6 +817,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -895,6 +906,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -954,6 +967,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1028,6 +1043,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1097,6 +1114,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1161,6 +1180,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1231,6 +1252,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_DESCRIPTION, "Basic Plan");
@@ -1307,6 +1330,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1473,6 +1498,8 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());

--- a/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
@@ -639,6 +639,7 @@ public class PaymentPlanApiIntegrationTest {
 				.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "5511275364819572");
 		parametersCC
 				.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2020/12");
+		parametersCC.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parametersCC.put(PayU.PARAMETERS.PAYMENT_METHOD, "MASTERCARD");
 
 		parametersCC.put(PayU.PARAMETERS.PAYER_NAME, "Manuel V");
@@ -956,6 +957,7 @@ public class PaymentPlanApiIntegrationTest {
 		// Credit card data
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "4005580000029205");
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2025/01");
+		parameters.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parameters.put(PayU.PARAMETERS.PAYMENT_METHOD, "VISA");
 
 		parameters.put(PayU.PARAMETERS.PAYER_NAME, "Luis Alejandro");
@@ -1086,6 +1088,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		try {
 			Subscription response = PayUSubscription.create(parameters);
@@ -1093,12 +1097,10 @@ public class PaymentPlanApiIntegrationTest {
 			LoggerUtil.info(RESPONSE_LOG_MESSAGE, response);
 
 			Assert.assertNotNull(response, "Empty subscription response");
-
 		} catch (ConnectionException e) {
 
 			// Service Unavailable
 			LoggerUtil.error(e.getMessage(), e);
-
 		} catch (SDKException e) {
 
 			// SDK error
@@ -1135,6 +1137,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");
@@ -1146,6 +1150,7 @@ public class PaymentPlanApiIntegrationTest {
 		// Credit card parameters
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "4005580000029205");
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2030/01");
+		parameters.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parameters.put(PayU.PARAMETERS.PAYMENT_METHOD, "VISA");
 
 		parameters.put(PayU.PARAMETERS.PAYER_NAME, "Santiago A");
@@ -1206,6 +1211,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1273,6 +1280,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1292,6 +1301,7 @@ public class PaymentPlanApiIntegrationTest {
 		// Credit card parameters
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "4005580000029205");
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2030/01");
+		parameters.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parameters.put(PayU.PARAMETERS.PAYMENT_METHOD, "VISA");
 
 		parameters.put(PayU.PARAMETERS.PAYER_NAME, "Santiago A");
@@ -1353,6 +1363,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		Subscription response = PayUSubscription.create(parameters);
 
@@ -1391,6 +1403,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 
@@ -1437,6 +1451,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_CODE, planCode);
@@ -1482,6 +1498,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1553,6 +1571,8 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_COUNTRY, "CO");
 		parameters.put(PayU.PARAMETERS.DELIVERY_POSTAL_CODE, "101010");
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
+		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
+		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");
@@ -1573,6 +1593,7 @@ public class PaymentPlanApiIntegrationTest {
 		// Credit card parameters
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_NUMBER, "4005580000029205");
 		parameters.put(PayU.PARAMETERS.CREDIT_CARD_EXPIRATION_DATE, "2030/01");
+		parameters.put(PayU.PARAMETERS.CREDIT_CARD_DOCUMENT, "123456789");
 		parameters.put(PayU.PARAMETERS.PAYMENT_METHOD, "VISA");
 
 		parameters.put(PayU.PARAMETERS.PAYER_NAME, "Santiago A");


### PR DESCRIPTION
Hola, se realizaron los siguientes cambios:

* Se agregaron los campos sourceId y description para la creación de suscripciones.
* Los campos son opcionales.

**NOTA:**
* La adición de estos campos en el API de payments aún está en desarrollo, sin embargo, al ser opcionales no se van a presentar errores ni conflictos si algún cliente los llega a enviar.

* Hay unas pruebas de integración que están fallando: 
PaymentPlanApiIntegrationTest.createCustomerWithBankAccount
PaymentPlanApiIntegrationTest.createCustomerWithBankAccountBrazil
BankAccountApiIntegrationTest.createBankAccount
BankAccountApiIntegrationTest.createBrazilBankAccount
BankAccountApiIntegrationTest.createSubscriptionExistingPlanAndNewBankAccountAndExistingCustomer  BankAccountApiIntegrationTest.createSubscriptionNewPlanAndNewBankAccountAndExistingCustomer
BankAccountApiIntegrationTest.createSubscriptionWithoutCustomer2

Y arrojan el siguiente error: "The payment method [Automatic Debit] is not avaiable for Account [X]"

Esas pruebas unitarias con errores no fueron modificadas en este pull request.