### PR TITLE
Se agregan nuevos campos para la migración de comercios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.9</version>
+	<version>1.1.10</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.8</version>
+	<version>1.1.9</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -380,6 +380,26 @@ public abstract class PayU {
 		/** The subscription ID from POL */
 		String SOURCE_ID = "sourceId";
 		
+		/**
+		 * To be used by migrated subscriptions. The buyer IP as 
+		 * informed by the origin platform.
+		 */
+		String BUYER_IP_SOURCE = "buyerIpSource";
+		
+		/**
+		 * To be used by migrated subscriptions. The number of payments 
+		 * charged on the origin platform at the moment that the subscription 
+		 * was migrated.
+		 */
+		String PAYMENTS_NUMBER_SOURCE = "paymentsNumberSource";
+
+		/**
+		 * To be used by migrated subscriptions. The number of the next payment
+		 * to be charged on the origin platform at the moment that the subscription 
+		 * was migrated. 
+		 */
+		String NEXT_PAYMENT_NUMBER_SOURCE = "nextPaymentNumberSource";
+
 	}
 
 }

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -384,21 +384,21 @@ public abstract class PayU {
 		 * To be used by migrated subscriptions. The buyer IP as 
 		 * informed by the origin platform.
 		 */
-		String BUYER_IP_SOURCE = "buyerIpSource";
+		String SOURCE_BUYER_IP = "sourceBuyerIp";
 		
 		/**
 		 * To be used by migrated subscriptions. The number of payments 
 		 * charged on the origin platform at the moment that the subscription 
 		 * was migrated.
 		 */
-		String PAYMENTS_NUMBER_SOURCE = "paymentsNumberSource";
+		String SOURCE_NUMBER_OF_PAYMENTS = "sourceNumberOfPayments";
 
 		/**
 		 * To be used by migrated subscriptions. The number of the next payment
 		 * to be charged on the origin platform at the moment that the subscription 
 		 * was migrated. 
 		 */
-		String NEXT_PAYMENT_NUMBER_SOURCE = "nextPaymentNumberSource";
+		String SOURCE_NEXT_PAYMENT_NUMBER = "sourceNextPaymentNumber";
 
 	}
 

--- a/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
+++ b/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
@@ -50,8 +50,8 @@ import com.payu.sdk.utils.JaxbUtil;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "id", "trialDays", "quantity", "installments", "currentPeriodStart", "currentPeriodEnd", "customer",
 		"plan", "creditCardToken", "bankAccountId", "termsAndConditionsAcepted", "immediatePayment", "deliveryAddress",
-		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2", "sourceId", "description", "buyerIpSource",
-		"paymentsNumberSource", "nextPaymentNumberSource" })
+		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2", "sourceId", "description", "sourceBuyerIp",
+		"sourceNumberOfPayments", "sourceNextPaymentNumber" })
 public class Subscription extends Request {
 
 	/**
@@ -168,21 +168,21 @@ public class Subscription extends Request {
 	 * To be used by migrated subscriptions. The buyer IP as 
 	 * informed by the origin platform.
 	 */
-	private String buyerIpSource;
+	private String sourceBuyerIp;
 	
 	/**
 	 * To be used by migrated subscriptions. The number of payments 
 	 * charged on the origin platform at the moment that the subscription 
 	 * was migrated.
 	 */
-	private Integer paymentsNumberSource;
+	private Integer sourceNumberOfPayments;
 
 	/**
 	 * To be used by migrated subscriptions. The number of the next payment
 	 * to be charged on the origin platform at the moment that the subscription 
 	 * was migrated. 
 	 */
-	private Integer nextPaymentNumberSource;
+	private Integer sourceNextPaymentNumber;
 
 	// -------------------------------------------------------
 	// GETTERS AND SETTERS
@@ -388,28 +388,28 @@ public class Subscription extends Request {
 	/**
 	 * Returns the source buyer IP
 	 * 
-	 * @return the buyerIpSource
+	 * @return the sourceBuyerIp
 	 */
-	public String getBuyerIpSource() {
-		return buyerIpSource;
+	public String getSourceBuyerIp() {
+		return sourceBuyerIp;
 	}
 
 	/**
-	 * Returns the source payments number
+	 * Returns the source number of payments
 	 * 
-	 * @return the paymentsNumberSource
+	 * @return the sourceNumberOfPayments
 	 */
-	public Integer getPaymentsNumberSource() {
-		return paymentsNumberSource;
+	public Integer getSourceNumberOfPayments() {
+		return sourceNumberOfPayments;
 	}
 
 	/**
 	 * Returns the source next payment number
 	 * 
-	 * @return the nextPaymentNumberSource
+	 * @return the sourceNextPaymentNumber
 	 */
-	public Integer getNextPaymentNumberSource() {
-		return nextPaymentNumberSource;
+	public Integer getSourceNextPaymentNumber() {
+		return sourceNextPaymentNumber;
 	}
 
 	/**
@@ -626,31 +626,31 @@ public class Subscription extends Request {
 	/**
 	 * Sets the source buyer IP
 	 * 
-	 * @param buyerIpSource
-	 * 			The buyer IP source
+	 * @param sourceBuyerIp
+	 * 			The source buyer IP
 	 */
-	public void setBuyerIpSource(String buyerIpSource) {
-		this.buyerIpSource = buyerIpSource;
+	public void setSourceBuyerIp(String sourceBuyerIp) {
+		this.sourceBuyerIp = sourceBuyerIp;
 	}
 
 	/**
-	 * Sets the source payments number
+	 * Sets the source number of payments
 	 * 
-	 * @param paymentsNumberSource
-	 * 			The source payment number
+	 * @param sourceNumberOfPayments
+	 * 			The source number of payments
 	 */
-	public void setPaymentsNumberSource(Integer paymentsNumberSource) {
-		this.paymentsNumberSource = paymentsNumberSource;
+	public void setSourceNumberOfPayments(Integer sourceNumberOfPayments) {
+		this.sourceNumberOfPayments = sourceNumberOfPayments;
 	}
 
 	/**
 	 * Sets the source next payment number
 	 * 
-	 * @param nextPaymentNumberSource
+	 * @param sourceNextPaymentNumber
 	 * 			The source next payment number
 	 */
-	public void setNextPaymentNumberSource(Integer nextPaymentNumberSource) {
-		this.nextPaymentNumberSource = nextPaymentNumberSource;
+	public void setSourceNextPaymentNumber(Integer sourceNextPaymentNumber) {
+		this.sourceNextPaymentNumber = sourceNextPaymentNumber;
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
+++ b/src/main/java/com/payu/sdk/paymentplan/model/Subscription.java
@@ -50,7 +50,8 @@ import com.payu.sdk.utils.JaxbUtil;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "id", "trialDays", "quantity", "installments", "currentPeriodStart", "currentPeriodEnd", "customer",
 		"plan", "creditCardToken", "bankAccountId", "termsAndConditionsAcepted", "immediatePayment", "deliveryAddress",
-		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2", "sourceId", "description" })
+		"notifyUrl", "sourceReference", "recurringBillItems", "extra1", "extra2", "sourceId", "description", "buyerIpSource",
+		"paymentsNumberSource", "nextPaymentNumberSource" })
 public class Subscription extends Request {
 
 	/**
@@ -163,6 +164,26 @@ public class Subscription extends Request {
 	 */
 	private String description;
 	
+	/**
+	 * To be used by migrated subscriptions. The buyer IP as 
+	 * informed by the origin platform.
+	 */
+	private String buyerIpSource;
+	
+	/**
+	 * To be used by migrated subscriptions. The number of payments 
+	 * charged on the origin platform at the moment that the subscription 
+	 * was migrated.
+	 */
+	private Integer paymentsNumberSource;
+
+	/**
+	 * To be used by migrated subscriptions. The number of the next payment
+	 * to be charged on the origin platform at the moment that the subscription 
+	 * was migrated. 
+	 */
+	private Integer nextPaymentNumberSource;
+
 	// -------------------------------------------------------
 	// GETTERS AND SETTERS
 	// -------------------------------------------------------
@@ -363,7 +384,34 @@ public class Subscription extends Request {
 		
 		return description;
 	}
-	
+
+	/**
+	 * Returns the source buyer IP
+	 * 
+	 * @return the buyerIpSource
+	 */
+	public String getBuyerIpSource() {
+		return buyerIpSource;
+	}
+
+	/**
+	 * Returns the source payments number
+	 * 
+	 * @return the paymentsNumberSource
+	 */
+	public Integer getPaymentsNumberSource() {
+		return paymentsNumberSource;
+	}
+
+	/**
+	 * Returns the source next payment number
+	 * 
+	 * @return the nextPaymentNumberSource
+	 */
+	public Integer getNextPaymentNumberSource() {
+		return nextPaymentNumberSource;
+	}
+
 	/**
 	 * Sets the subscription identifier
 	 *
@@ -575,6 +623,36 @@ public class Subscription extends Request {
 		this.description = description;
 	}
 	
+	/**
+	 * Sets the source buyer IP
+	 * 
+	 * @param buyerIpSource
+	 * 			The buyer IP source
+	 */
+	public void setBuyerIpSource(String buyerIpSource) {
+		this.buyerIpSource = buyerIpSource;
+	}
+
+	/**
+	 * Sets the source payments number
+	 * 
+	 * @param paymentsNumberSource
+	 * 			The source payment number
+	 */
+	public void setPaymentsNumberSource(Integer paymentsNumberSource) {
+		this.paymentsNumberSource = paymentsNumberSource;
+	}
+
+	/**
+	 * Sets the source next payment number
+	 * 
+	 * @param nextPaymentNumberSource
+	 * 			The source next payment number
+	 */
+	public void setNextPaymentNumberSource(Integer nextPaymentNumberSource) {
+		this.nextPaymentNumberSource = nextPaymentNumberSource;
+	}
+
 	/* (non-Javadoc)
 	 * @see com.payu.sdk.model.request.Request#getBaseRequestUrl(java.lang.String, com.payu.sdk.constants.Resources.RequestMethod)
 	 */

--- a/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
@@ -643,9 +643,9 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		String description = getParameter(parameters, PayU.PARAMETERS.DESCRIPTION);
 		
 		// Migrated subscriptions parameters
-		String buyerIpSource = getParameter(parameters, PayU.PARAMETERS.BUYER_IP_SOURCE);
-		Integer paymentsNumberSource = getIntegerParameter(parameters, PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE); 
-		Integer nextPaymentNumberSource = getIntegerParameter(parameters, PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE);
+		String sourceBuyerIP = getParameter(parameters, PayU.PARAMETERS.SOURCE_BUYER_IP);
+		Integer sourceNumberOfPayments = getIntegerParameter(parameters, PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS); 
+		Integer sourceNextPaymentNumber = getIntegerParameter(parameters, PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER);
 		
 		// Subscription basic parameters
 		Subscription request = new Subscription();
@@ -664,9 +664,9 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		request.setExtra1(extra2);
 		request.setSourceId(sourceId);
 		request.setDescription(description);
-		request.setBuyerIpSource(buyerIpSource);
-		request.setPaymentsNumberSource(paymentsNumberSource);
-		request.setNextPaymentNumberSource(nextPaymentNumberSource);
+		request.setSourceBuyerIp(sourceBuyerIP);
+		request.setSourceNumberOfPayments(sourceNumberOfPayments);
+		request.setSourceNextPaymentNumber(sourceNextPaymentNumber);
 		
 
 		// Subscription complex parameters (customer and plan)

--- a/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
+++ b/src/main/java/com/payu/sdk/utils/PaymentPlanRequestUtil.java
@@ -642,6 +642,11 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		Long sourceId = getLongParameter(parameters, PayU.PARAMETERS.SOURCE_ID);
 		String description = getParameter(parameters, PayU.PARAMETERS.DESCRIPTION);
 		
+		// Migrated subscriptions parameters
+		String buyerIpSource = getParameter(parameters, PayU.PARAMETERS.BUYER_IP_SOURCE);
+		Integer paymentsNumberSource = getIntegerParameter(parameters, PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE); 
+		Integer nextPaymentNumberSource = getIntegerParameter(parameters, PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE);
+		
 		// Subscription basic parameters
 		Subscription request = new Subscription();
 		setAuthenticationCredentials(parameters, request);
@@ -659,6 +664,10 @@ public final class PaymentPlanRequestUtil extends CommonRequestUtil {
 		request.setExtra1(extra2);
 		request.setSourceId(sourceId);
 		request.setDescription(description);
+		request.setBuyerIpSource(buyerIpSource);
+		request.setPaymentsNumberSource(paymentsNumberSource);
+		request.setNextPaymentNumberSource(nextPaymentNumberSource);
+		
 
 		// Subscription complex parameters (customer and plan)
 		request.setPlan(plan);

--- a/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
@@ -460,9 +460,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -525,9 +525,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -603,9 +603,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -762,9 +762,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -831,9 +831,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -923,9 +923,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -987,9 +987,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1066,9 +1066,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1140,9 +1140,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1209,9 +1209,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1284,9 +1284,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_DESCRIPTION, "Basic Plan");
@@ -1365,9 +1365,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1536,9 +1536,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());

--- a/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/BankAccountApiIntegrationTest.java
@@ -460,6 +460,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -522,6 +525,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -597,6 +603,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -753,6 +762,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -819,6 +831,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -908,6 +923,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "David");
@@ -969,6 +987,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1045,6 +1066,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1116,6 +1140,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1182,6 +1209,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_ID, planId);
@@ -1254,6 +1284,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_DESCRIPTION, "Basic Plan");
@@ -1332,6 +1365,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());
@@ -1500,6 +1536,9 @@ public class BankAccountApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 		
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customer.getId());

--- a/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
@@ -1090,9 +1090,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		try {
 			Subscription response = PayUSubscription.create(parameters);
@@ -1142,9 +1142,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");
@@ -1219,9 +1219,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1291,9 +1291,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1377,9 +1377,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		Subscription response = PayUSubscription.create(parameters);
 
@@ -1420,9 +1420,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 
@@ -1471,9 +1471,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_CODE, planCode);
@@ -1521,9 +1521,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1597,9 +1597,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
-		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
-		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
-		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
+		parameters.put(PayU.PARAMETERS.SOURCE_BUYER_IP, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.SOURCE_NUMBER_OF_PAYMENTS, "6");
+		parameters.put(PayU.PARAMETERS.SOURCE_NEXT_PAYMENT_NUMBER, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");

--- a/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
+++ b/src/test/java/com/payu/sdk/paymentplan/PaymentPlanApiIntegrationTest.java
@@ -1090,6 +1090,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		try {
 			Subscription response = PayUSubscription.create(parameters);
@@ -1139,6 +1142,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");
@@ -1213,6 +1219,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1282,6 +1291,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1365,6 +1377,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		Subscription response = PayUSubscription.create(parameters);
 
@@ -1405,6 +1420,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 
@@ -1453,6 +1471,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Plan parameters
 		parameters.put(PayU.PARAMETERS.PLAN_CODE, planCode);
@@ -1500,6 +1521,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_ID, customerId);
@@ -1573,6 +1597,9 @@ public class PaymentPlanApiIntegrationTest {
 		parameters.put(PayU.PARAMETERS.DELIVERY_PHONE, "777123123");
 		parameters.put(PayU.PARAMETERS.SOURCE_ID, "12345");
 		parameters.put(PayU.PARAMETERS.DESCRIPTION, "Test description");
+		parameters.put(PayU.PARAMETERS.BUYER_IP_SOURCE, "123.321.123.321");
+		parameters.put(PayU.PARAMETERS.PAYMENTS_NUMBER_SOURCE, "6");
+		parameters.put(PayU.PARAMETERS.NEXT_PAYMENT_NUMBER_SOURCE, "7");
 
 		// Customer parameters
 		parameters.put(PayU.PARAMETERS.CUSTOMER_NAME, "Oscar");


### PR DESCRIPTION
Se agregan los campos SOURCE_BUYER_IP, SOURCE_NUMBER_OF_PAYMENTS y SOURCE_NEXT_PAYMENT_NUMBER a la suscripción.

Los cambios son compatibles hacia atrás.