### PR TITLE
Pagosonlinepps 33399 ajustar api creacion transacciones bcash con codigos respuesta juan alvis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.11</version>
+	<version>1.1.12</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.14</version>
+	<version>1.1.15</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -108,7 +108,39 @@ public enum TransactionResponseCode {
 	/** Transaction was not fixed due to incomplete data code */
 	ERROR_FIXING_INCOMPLETE_DATA("10006"),
 	/** Awaiting PSE confirmation **/
-	PENDING_AWAITING_PSE_CONFIRMATION("");
+	PENDING_AWAITING_PSE_CONFIRMATION("28"),
+	/** **/
+	INVALID_RESPONSE_PARTIAL_APPROVAL("10007"),
+
+	/** The transaction was declined by test mode.*/
+	DECLINED_TEST_MODE_NOT_ALLOWED("40"),
+	/** **/
+	ERROR_CONVERTING_DEPOSIT_AMOUNTS("56"),
+	/** The transaction is related to a bank account with an error during its activation process */
+	BANK_ACCOUNT_ACTIVATION_ERROR("31"),
+	/** The bank account is not authorized for automatic debit. */
+	BANK_ACCOUNT_NOT_AUTHORIZED_FOR_AUTOMATIC_DEBIT("32"),
+	/** The bank account agency value is invalid. */
+	INVALID_AGENCY_BANK_ACCOUNT("33"),
+	/** The bank account is invalid. */
+	INVALID_BANK_ACCOUNT("34"),
+	/** The bank is invalid. */
+	INVALID_BANK("35"),
+	/** The transaction was sent to answer questionnaire. */
+	PENDING_ANSWER_MAF_QUESTIONNAIRE("16"),
+	/** The transaction is pending for payment in entity*/
+	PENDING_PAYMENT_IN_ENTITY("25"),
+	/** The transaction is pending for payment in bank */
+	PENDING_PAYMENT_IN_BANK("26"),
+	/** The transaction is pending to sent tot financial entity*/
+	PENDING_SENT_TO_FINANCIAL_ENTITY("29"),
+	/** The transaction is pending for notifying entity*/
+	PENDING_NOTIFYING_ENTITY("30"),
+
+	/** The transaction cancelled by payer before being processed */
+	CANCELLED_TRANSACTION_PAYER("10008"),
+	/** The transaction cancelled by merchant before being processed */
+	CANCELLED_TRANSACTION_MERCHANT("10009");
 
 	/**
 	 * The transaction response code.
@@ -120,7 +152,7 @@ public enum TransactionResponseCode {
 	 *
 	 * @param code the transaction response code.
 	 */
-	private TransactionResponseCode(String code) {
+	private TransactionResponseCode(String code) {																																																																																																																																																																																																																																																																																						xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 		this.code = code;
 	}
 

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -152,7 +152,7 @@ public enum TransactionResponseCode {
 	 *
 	 * @param code the transaction response code.
 	 */
-	private TransactionResponseCode(String code) {																																																																																																																																																																																																																																																																																						xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+	private TransactionResponseCode(String code) {
 		this.code = code;
 	}
 

--- a/src/main/resources/release_notes/1.1.15.txt
+++ b/src/main/resources/release_notes/1.1.15.txt
@@ -1,0 +1,8 @@
+2016-11-10
+----------
+*   se modifica PENDING_AWAITING_PSE_CONFIRMATION(""); a PENDING_AWAITING_PSE_CONFIRMATION("28"); así estaba en "com.pagosonline.ppp4.core.common.model.TransactionResponseCode".
+*   Se agregan los campos en el enumerado desde payments-api "com.pagosonline.ppp4.core.common.model.TransactionResponseCode" hacia "com.payu.sdk.model.TransactionResponseCode"
+
+
+Issue:
+https://pagosonline.jira.com/browse/PAGOSONLINEPPS-33399


### PR DESCRIPTION
* Se añaden enumerados de respuestas de transacciones desde "com.pagosonline.ppp4.core.common.model.TransactionResponseCode"