### PR TITLE
IOCC-49 Ajustar payu-latam-java-payments-sdk para OCCS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2.4</version>
+	<version>1.2.5</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/PayU.java
+++ b/src/main/java/com/payu/sdk/PayU.java
@@ -117,6 +117,8 @@ public abstract class PayU {
 		String SIGNATURE = "signature";
 		/** The transaction identifier. */
 		String TRANSACTION_ID = "transactionId";
+		/** The transaction source */
+		String TRANSACTION_SOURCE = "transactionSource";
 		/** The credit card token id. */
 		String TOKEN_ID = "tokenId";
 		/** the batch token id. */

--- a/src/main/java/com/payu/sdk/model/TransactionSource.java
+++ b/src/main/java/com/payu/sdk/model/TransactionSource.java
@@ -35,6 +35,10 @@ public enum TransactionSource {
 	/**
 	 * The default transaction source in the PayU SDK.
 	 */
-	PAYU_SDK;
+	PAYU_SDK,
+	/**
+	 * Oracle Commerce Cloud Service API
+	 */
+	OCCS_API;
 
 }

--- a/src/main/resources/release_notes/1.2.5.txt
+++ b/src/main/resources/release_notes/1.2.5.txt
@@ -1,0 +1,10 @@
+2017-08-15
+----------
+* IOCC-49 Ajustar payu-latam-java-payments-sdk para OCCS
+  * Crear TransactionSource.OCCS_API.
+  * Crear nuevo parámetro PayU.PARAMETERS.TRANSACTION_SOURCE.
+  * Usar PayU.PARAMETERS.LANGUAGE para establecer el idioma de la petición
+    y la orden.
+
+Issue:
+https://pagosonline.jira.com/browse/IOCC-49

--- a/src/test/java/com/payu/sdk/utils/RequestUtilTest.java
+++ b/src/test/java/com/payu/sdk/utils/RequestUtilTest.java
@@ -23,15 +23,26 @@
  */
 package com.payu.sdk.utils;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import java.util.Set;
 
 import com.payu.sdk.PayU;
+import com.payu.sdk.exceptions.InvalidParametersException;
+import com.payu.sdk.model.Language;
+import com.payu.sdk.model.Transaction;
+import com.payu.sdk.model.TransactionSource;
+import com.payu.sdk.model.TransactionType;
+import com.payu.sdk.model.request.CommandRequest;
+import com.payu.sdk.model.request.Request;
+import com.payu.sdk.payments.model.PaymentRequest;
 import com.payu.sdk.reporting.model.ReportingRequest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 /**
  * @author raphael.batista
@@ -41,6 +52,14 @@ import com.payu.sdk.reporting.model.ReportingRequest;
  */
 public class RequestUtilTest {
 
+	private static final Set<TransactionType> TRANSACTION_TYPES_WITH_ORDER = Collections.unmodifiableSet(EnumSet.of(
+			TransactionType.AUTHORIZATION,
+			TransactionType.AUTHORIZATION_AND_CAPTURE,
+			TransactionType.CAPTURE,
+			TransactionType.VOID,
+			TransactionType.REFUND,
+			TransactionType.PARTIAL_REFUND));
+
 	/**
 	 * Reset the static variables for each test
 	 */
@@ -48,6 +67,7 @@ public class RequestUtilTest {
 	public void before() {
 		PayU.apiKey = null;
 		PayU.apiLogin = null;
+		PayU.language = null;
 	}
 	
 	/**
@@ -114,6 +134,250 @@ public class RequestUtilTest {
 		
 		Assert.assertEquals(reportingRequest.getMerchant().getApiKey(), expectedApiKey);
 		Assert.assertEquals(reportingRequest.getMerchant().getApiLogin(), expectedApiLogin);
+	}
+
+	@Test(dataProvider = "transactionSources")
+	public void shouldBuildATransactionWithTheCorrectTransactionSource(Map<String, String> parameters,
+			TransactionType transactionType, TransactionSource expectedTransactionSource) throws InvalidParametersException {
+
+		Transaction transaction = RequestUtil.buildTransaction(parameters, transactionType);
+		Assert.assertEquals(transaction.getSource(), expectedTransactionSource);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAReportingPingRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		CommandRequest request = RequestUtil.buildReportingPingRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAnOrderReportingDetailsWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) throws InvalidParametersException {
+
+		PayU.language = payuLanguage;
+		CommandRequest request = RequestUtil.buildOrderReportingDetails(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAnOrderReportingByReferenceCodeWithTheCorrectLanguage(Language payuLanguage,
+			Map<String, String> parameters, Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		CommandRequest request = RequestUtil.buildOrderReportingByReferenceCode(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildATransactionResponseWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		CommandRequest request = RequestUtil.buildTransactionResponse(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildACreateTokenRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) throws InvalidParametersException {
+
+		PayU.language = payuLanguage;
+		Request request = RequestUtil.buildCreateTokenRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAGetCreditCardTokensRequestWithTheCorrectLanguage(Language payuLanguage,
+			Map<String, String> parameters, Language expectedLanguage) throws InvalidParametersException {
+
+		PayU.language = payuLanguage;
+		Request request = RequestUtil.buildGetCreditCardTokensRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildARemoveTokenRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		Request request = RequestUtil.buildRemoveTokenRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAPaymentsPingRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		PaymentRequest request = RequestUtil.buildPaymentsPingRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@Test(dataProvider = "languagesAndTransactionTypes")
+	public void shouldBuildAPaymentRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			TransactionType transactionType, Language expectedLanguage) throws InvalidParametersException {
+
+		PayU.language = payuLanguage;
+		Request request = RequestUtil.buildPaymentRequest(parameters, transactionType);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+		if (TRANSACTION_TYPES_WITH_ORDER.contains(transactionType)) {
+			Assert.assertEquals(((PaymentRequest) request).getTransaction().getOrder().getLanguage(), expectedLanguage);
+		}
+	}
+
+	@Test(dataProvider = "languages")
+	public void shouldBuildAPaymentMethodsListRequestWithTheCorrectLanguage(Language payuLanguage, Map<String, String> parameters,
+			Language expectedLanguage) {
+
+		PayU.language = payuLanguage;
+		Request request = RequestUtil.buildPaymentMethodsListRequest(parameters);
+		Assert.assertEquals(request.getLanguage(), expectedLanguage);
+	}
+
+	@DataProvider
+	private static Object[][] transactionSources() {
+
+		return new Object[][] { { Collections.emptyMap(), null, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						null,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						null,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.AUTHORIZATION, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.AUTHORIZATION,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.AUTHORIZATION,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.AUTHORIZATION_AND_CAPTURE, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.AUTHORIZATION_AND_CAPTURE,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.AUTHORIZATION_AND_CAPTURE,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.CAPTURE, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.CAPTURE,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.CAPTURE,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.CANCELLATION, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.CANCELLATION,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.CANCELLATION,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.VOID, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.VOID,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.VOID,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.REFUND, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.REFUND,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.REFUND,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.CREDIT, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.CREDIT,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.CREDIT,
+						TransactionSource.OCCS_API },
+				{ Collections.emptyMap(), TransactionType.PARTIAL_REFUND, TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.PAYU_SDK.name()),
+						TransactionType.PARTIAL_REFUND,
+						TransactionSource.PAYU_SDK },
+				{ Collections.singletonMap(PayU.PARAMETERS.TRANSACTION_SOURCE, TransactionSource.OCCS_API.name()),
+						TransactionType.PARTIAL_REFUND,
+						TransactionSource.OCCS_API } };
+	}
+
+	@DataProvider
+	private static Object[][] languages() {
+
+		return new Object[][] { { null, Collections.emptyMap(), null },
+				{ Language.es, Collections.emptyMap(), Language.es },
+				{ Language.en, Collections.emptyMap(), Language.en },
+				{ Language.pt, Collections.emptyMap(), Language.pt },
+				{ null, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()), Language.es },
+				{ Language.es, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()), Language.es },
+				{ Language.en, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()), Language.es },
+				{ Language.pt, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()), Language.es },
+				{ null, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()), Language.en },
+				{ Language.es, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()), Language.en },
+				{ Language.en, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()), Language.en },
+				{ Language.pt, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()), Language.en },
+				{ null, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()), Language.pt },
+				{ Language.es, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()), Language.pt },
+				{ Language.en, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()), Language.pt },
+				{ Language.pt, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()), Language.pt } };
+	}
+
+	@DataProvider
+	private static Object[][] languagesAndTransactionTypes() {
+
+		return new Object[][] { { null, Collections.emptyMap(), TransactionType.AUTHORIZATION, null },
+				{ Language.es, Collections.emptyMap(), TransactionType.AUTHORIZATION_AND_CAPTURE, Language.es },
+				{ Language.en, Collections.emptyMap(), TransactionType.CAPTURE, Language.en },
+				{ Language.pt, Collections.emptyMap(), TransactionType.CANCELLATION, Language.pt },
+				{ null,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()),
+						TransactionType.VOID,
+						Language.es },
+				{ Language.es,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()),
+						TransactionType.REFUND,
+						Language.es },
+				{ Language.en,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()),
+						TransactionType.CREDIT,
+						Language.es },
+				{ Language.pt,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.es.name()),
+						TransactionType.PARTIAL_REFUND,
+						Language.es },
+				{ null, Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()), null, Language.en },
+				{ Language.es,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()),
+						TransactionType.AUTHORIZATION,
+						Language.en },
+				{ Language.en,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()),
+						TransactionType.AUTHORIZATION_AND_CAPTURE,
+						Language.en },
+				{ Language.pt,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.en.name()),
+						TransactionType.CAPTURE,
+						Language.en },
+				{ null,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()),
+						TransactionType.CANCELLATION,
+						Language.pt },
+				{ Language.es,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()),
+						TransactionType.VOID,
+						Language.pt },
+				{ Language.en,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()),
+						TransactionType.REFUND,
+						Language.pt },
+				{ Language.pt,
+						Collections.singletonMap(PayU.PARAMETERS.LANGUAGE, Language.pt.name()),
+						TransactionType.CREDIT,
+						Language.pt } };
 	}
 
 }

--- a/src/test/java/com/payu/sdk/utils/RequestUtilTest.java
+++ b/src/test/java/com/payu/sdk/utils/RequestUtilTest.java
@@ -65,6 +65,7 @@ public class RequestUtilTest {
 	 */
 	@BeforeMethod
 	public void before() {
+		PayU.merchantId = null;
 		PayU.apiKey = null;
 		PayU.apiLogin = null;
 		PayU.language = null;


### PR DESCRIPTION
* Crear TransactionSource.OCCS_API.
* Crear nuevo parámetro PayU.PARAMETERS.TRANSACTION_SOURCE.
* Usar PayU.PARAMETERS.LANGUAGE para establecer el idioma de la petición y la orden.