### PR TITLE
PAGOSONLINEPPS-42070 Google - Ajuste SDK para recibir el tipo de tarjeta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.1</version>
+	<version>1.3.2</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/src/main/java/com/payu/sdk/model/CreditCard.java
+++ b/src/main/java/com/payu/sdk/model/CreditCard.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -43,9 +44,17 @@ public class CreditCard extends AbstractCardData implements Serializable {
 	/** The generated serial version Id */
 	private static final long serialVersionUID = 8390294592569483576L;
 
+	/**The credit card number. */
+	@XmlElement(required=false)
+	private String cardType;
+
+	public void setCardType(String cardType) {
+		this.cardType = cardType;
+	}
+
 	@Override
 	public CardType getCardType() {
-		return CardType.CREDIT;
+		return CardType.valueOf(cardType);
 	}
 	
 }

--- a/src/main/java/com/payu/sdk/model/TransactionResponse.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponse.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.payu.sdk.utils.xml.DateAdapter;
+import com.payu.sdk.utils.xml.MapAdditionalInfoAdapter;
 import com.payu.sdk.utils.xml.MapExtraParameterAdapter;
 
 /**
@@ -99,6 +100,11 @@ public class TransactionResponse implements Serializable {
 	/** The extra parameters. */
 	@XmlJavaTypeAdapter(MapExtraParameterAdapter.class)
 	private Map<String, Object> extraParameters;
+
+	/** The addicional info fields */
+        @XmlJavaTypeAdapter(MapAdditionalInfoAdapter.class)
+        private Map<String, String> additionalInfo;
+
 
 	/**
 	 * Returns the order id
@@ -243,6 +249,17 @@ public class TransactionResponse implements Serializable {
 	public Map<String, Object> getExtraParameters() {
 		return extraParameters;
 	}
+
+	/**
+         * Returns the additional info map
+         *
+         * @return the additional info
+         */
+        public Map<String, String> getAdditionalInfo() {
+
+                return additionalInfo;
+        }
+
 
 	/**
 	 * Sets the order id
@@ -405,4 +422,13 @@ public class TransactionResponse implements Serializable {
 		this.extraParameters = extraParameters;
 	}
 
+	/**
+         * Sets the additional info map
+         *
+         * @param additionalInfo the additional info to set
+         */
+        public void setAdditionalInfo(Map<String, String> additionalInfo) {
+
+                this.additionalInfo = additionalInfo;
+        }
 }

--- a/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoAdapter.java
+++ b/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoAdapter.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 developers-payu-latam
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.payu.sdk.utils.xml;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
@@ -9,7 +32,7 @@ import java.util.Map;
  * vice versa.
  *
  * @author PayU Latam
- * @since 1.2.2
+ * @since 1.3.2
  * @version 1.0.0, 15/06/2018
  */
 public class MapAdditionalInfoAdapter extends XmlAdapter<MapAdditionalInfoElement, Map<String, String>> {

--- a/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoAdapter.java
+++ b/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoAdapter.java
@@ -1,0 +1,40 @@
+package com.payu.sdk.utils.xml;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility to adapt additional info into {@link MapAdditionalInfoElement} and
+ * vice versa.
+ *
+ * @author PayU Latam
+ * @since 1.2.2
+ * @version 1.0.0, 15/06/2018
+ */
+public class MapAdditionalInfoAdapter extends XmlAdapter<MapAdditionalInfoElement, Map<String, String>> {
+
+	@Override
+	public MapAdditionalInfoElement marshal(Map<String, String> v) throws Exception {
+
+		if (v == null || v.isEmpty()) {
+			return null;
+		}
+
+		MapAdditionalInfoElement map = new MapAdditionalInfoElement();
+		map.setCardType(v.get("cardType"));
+		return map;
+	}
+
+	@Override
+	public Map<String, String> unmarshal(MapAdditionalInfoElement v) throws Exception {
+
+		if (v == null) {
+			return null;
+		}
+
+		Map<String, String> map = new HashMap<String, String>(1);
+		map.put("cardType", v.getCardType());
+		return map;
+	}
+}

--- a/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
+++ b/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
@@ -35,7 +35,7 @@ import java.util.List;
  *
  * @author PayU Latam
  * @since 1.3.2
- * @version 1.0.0
+ * @version 1.0.0, 15/06/2018
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "additionalInfo")

--- a/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
+++ b/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
@@ -21,40 +21,48 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.payu.sdk.model;
-
-import java.io.Serializable;
+package com.payu.sdk.utils.xml;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Represents a credit card in the PayU SDK.
+ * Utility to encapsulate additional info tag data.
  *
  * @author PayU Latam
- * @since 1.0.0
- * @version 1.0.0, 06/09/2013
+ * @since 1.2.2
+ * @version 1.0.0
  */
-@XmlRootElement(name="creditCard")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class CreditCard extends AbstractCardData implements Serializable {
+@XmlRootElement(name = "additionalInfo")
+public class MapAdditionalInfoElement {
 
-	/** The generated serial version Id */
-	private static final long serialVersionUID = 8390294592569483576L;
-
-	/**The card type */
-	@XmlElement(required=false)
+	/**
+	 * The card type field
+	 */
+	@XmlElement(name = "cardType")
 	private String cardType;
 
+	/**
+	 * Returns the cardType
+	 *
+	 * @return the card type
+	 */
+	public String getCardType() {
+		return cardType;
+	}
+
+	/**
+	 * Sets the list of entries
+	 *
+	 * @param cardType The card type
+	 */
 	public void setCardType(String cardType) {
 		this.cardType = cardType;
 	}
 
-	@Override
-	public CardType getCardType() {
-		return CardType.valueOf(cardType);
-	}
-	
 }

--- a/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
+++ b/src/main/java/com/payu/sdk/utils/xml/MapAdditionalInfoElement.java
@@ -34,7 +34,7 @@ import java.util.List;
  * Utility to encapsulate additional info tag data.
  *
  * @author PayU Latam
- * @since 1.2.2
+ * @since 1.3.2
  * @version 1.0.0
  */
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/resources/release_notes/1.3.2.txt
+++ b/src/main/resources/release_notes/1.3.2.txt
@@ -1,0 +1,5 @@
+2018-06-18
+----------
+Interpretar el atributo cardType de la tarjeta de crédito en la respuesta de PaymentsAPI/ReportsAPI
+Issue:
+https://pagosonline.jira.com/browse/PAGOSONLINEPPS-42070


### PR DESCRIPTION
Agregar campo cardType a datos de tarjeta de crédito. Agregar adaptadores para interpretar el nuevo campo. Ajustes de versionamiento.