### PR TITLE
Adicionando tipo de cartão Hipercard

### DIFF
--- a/src/main/java/com/payu/sdk/model/PaymentMethod.java
+++ b/src/main/java/com/payu/sdk/model/PaymentMethod.java
@@ -41,6 +41,8 @@ public enum PaymentMethod {
 	VISA(PaymentMethodType.CREDIT_CARD),
 
 	AMEX(PaymentMethodType.CREDIT_CARD),
+	
+	HIPERCARD(PaymentMethodType.CREDIT_CARD),
 
 	DINERS(PaymentMethodType.CREDIT_CARD),
 


### PR DESCRIPTION
No Brasil não esta aceitando o cartão de crédito HIPERCARD, porém via API rest é aceito o  paymentMethod = HIPERCARD