### PR TITLE
Error enum type

### DIFF
--- a/src/main/java/com/payu/sdk/model/CreditCard.java
+++ b/src/main/java/com/payu/sdk/model/CreditCard.java
@@ -54,7 +54,7 @@ public class CreditCard extends AbstractCardData implements Serializable {
 
 	@Override
 	public CardType getCardType() {
-		return CardType.valueOf(cardType);
+		return CardType.CREDIT;
 	}
 	
 }


### PR DESCRIPTION
- Actualmente en la clase CardType tiene `CardType.valueOf(cardType);` lo cual es erroneo ya que existe el enumerable `CardType.CREDIT` referente a la tarjeta de credito, este cambio actualmente esta funcionando en DebitCard clase, pero en su caso CardType.DEBIT