### PR TITLE
Feature/s2 p 382 pse response codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk9
 after_script: mvn test 
 notifications:
   recipients:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.payulatam.sdk</groupId>
 	<artifactId>payu-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.5</version>
+	<version>1.3.6</version>
 
 	<name>payu-java-sdk</name>
 	<description>PAYU SDK - Java 6+</description>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
+			<scope>test</scope>
 			<version>2.3.0</version>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.3.2</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
 	</dependencies>
 
 

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -37,7 +37,7 @@ public enum TransactionResponseCode {
 	 */
 	ANTIFRAUD_REJECTED("23"),
 	/**
-	 * Transaction rejected on suspicion of fraud at the financial institution
+	 * Transaction rejected due to suspicion of fraud in the financial entity
 	 */
 	BANK_FRAUD_REJECTED("10011"),
 	/**
@@ -176,16 +176,15 @@ public enum TransactionResponseCode {
 	PENDING_AWAITING_PSE_CONFIRMATION("28"),
 	/**
 	 *
-	 **/
+	 */
 	INVALID_RESPONSE_PARTIAL_APPROVAL("10007"),
-
 	/**
 	 * The transaction was declined by test mode.
 	 */
 	DECLINED_TEST_MODE_NOT_ALLOWED("40"),
 	/**
-	 *
-	 **/
+	 * Transaction amounts could not be converted
+	 */
 	ERROR_CONVERTING_DEPOSIT_AMOUNTS("56"),
 	/**
 	 * The transaction is related to a bank account with an error during its activation process
@@ -233,17 +232,16 @@ public enum TransactionResponseCode {
 	 */
 	CANCELLED_TRANSACTION_PAYER("10008"),
 	/**
-	 * The transaction was cancelled by the merchant before being processed
+	 * The transaction was canceled by the merchant before being processed
 	 */
 	CANCELLED_TRANSACTION_MERCHANT("10009"),
 	/**
-	 * The transaction was abandoned by the client at gateway
-	 * The transaction was abandoned (Cash)
+	 * The transaction was abandoned by the client at gateway The transaction was abandoned (Cash)
 	 */
 	ABANDONED_TRANSACTION("19"),
 
 	/**
-	 * The first refund transaction of dispersion was Approved but is necessary to execute a second refund transaction by a clinic
+	 * The first refund transaction of dispersion was Approved but it is necessary to execute a second refund transaction by a clinic
 	 * <ol>
 	 * 	<li>First transaction = Airline values</li>
 	 * 	<li>Second transaction = Agency values</li>

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -1,148 +1,259 @@
 /**
- * The MIT License (MIT)
- *
- * Copyright (c) 2016 developers-payu-latam
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * The MIT License (MIT) Copyright (c) 2016 developers-payu-latam Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission
+ * notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 package com.payu.sdk.model;
-
 
 /**
  * Enum representing a response code for a transaction in the PayU SDK.
  *
  * @author PayU Latam
- * @since 1.0.0
  * @version 1.0.0, 21/08/2013
+ * @since 1.0.0
  */
 public enum TransactionResponseCode {
 
-	/** Error transaction code */
+	/**
+	 * Error transaction code
+	 */
 	ERROR("0"),
-	/** Approved transaction code */
+	/**
+	 * Approved transaction code
+	 */
 	APPROVED("1"),
-	/** Transaction declined by the entity code */
+	/**
+	 * Transaction declined by the entity code
+	 */
 	ENTITY_DECLINED("5"),
-	/** Transaction rejected by anti fraud system code */
+	/**
+	 * Transaction rejected by anti fraud system code
+	 */
 	ANTIFRAUD_REJECTED("23"),
-	/** Transaction rejected due to suspected fraud at the financial institution */
+	/**
+	 * Transaction rejected due to suspected fraud at the financial institution
+	 */
 	BANK_FRAUD_REJECTED("10011"),
-	/** Transaction review pending code */
+	/**
+	 * Transaction review pending code
+	 */
 	PENDING_TRANSACTION_REVIEW("15"),
-	/** Transaction expired code */
+	/**
+	 * Transaction expired code
+	 */
 	EXPIRED_TRANSACTION("50"),
-	/** The payment provider had an internal error code */
+	/**
+	 * The payment provider had an internal error code
+	 */
 	INTERNAL_PAYMENT_PROVIDER_ERROR("51"),
-	/** The payment provider is not active code */
+	/**
+	 * The payment provider is not active code
+	 */
 	INACTIVE_PAYMENT_PROVIDER("52"),
-	/** The digital certificate could not be found code */
+	/**
+	 * The digital certificate could not be found code
+	 */
 	DIGITAL_CERTIFICATE_NOT_FOUND("9995"),
-	/** Transaction rejected by payment network */
+	/**
+	 * Transaction rejected by payment network
+	 */
 	PAYMENT_NETWORK_REJECTED("4"),
-	/** Invalid data code */
+	/**
+	 * Invalid data code
+	 */
 	INVALID_EXPIRATION_DATE_OR_SECURITY_CODE("12"),
-	/** Insufficient funds code */
+	/**
+	 * Insufficient funds code
+	 */
 	INSUFFICIENT_FUNDS("6"),
-	/** Credit card not authorized code */
+	/**
+	 * Credit card not authorized code
+	 */
 	CREDIT_CARD_NOT_AUTHORIZED_FOR_INTERNET_TRANSACTIONS("22"),
-	/** Transaction is not valid code */
+	/**
+	 * Transaction is not valid code
+	 */
 	INVALID_TRANSACTION("14"),
-	/** Credit card is not valid code */
+	/**
+	 * Credit card is not valid code
+	 */
 	INVALID_CARD("7"),
-	/** Credit card expired code */
+	/**
+	 * Credit card expired code
+	 */
 	EXPIRED_CARD("9"),
-	/** Credit card is restricted code */
+	/**
+	 * Credit card is restricted code
+	 */
 	RESTRICTED_CARD("10"),
-	/** Need to contact the entity code */
+	/**
+	 * Need to contact the entity code
+	 */
 	CONTACT_THE_ENTITY("8"),
-	/** Need to repeat transaction code */
+	/**
+	 * Need to repeat transaction code
+	 */
 	REPEAT_TRANSACTION("13"),
-	/** Entity sent an error message code */
+	/**
+	 * Entity sent an error message code
+	 */
 	ENTITY_MESSAGING_ERROR("9997"),
-	/** Transaction confirmation is pending code */
+	/**
+	 * Transaction confirmation is pending code
+	 */
 	PENDING_TRANSACTION_CONFIRMATION("9994"),
-	/** Bank could not be reached code */
+	/**
+	 * Bank could not be reached code
+	 */
 	BANK_UNREACHABLE("53"),
-	/** Amount not valid code */
+	/**
+	 * Amount not valid code
+	 */
 	EXCEEDED_AMOUNT("17"),
-	/** Transaction not accepted code */
+	/**
+	 * Transaction not accepted code
+	 */
 	NOT_ACCEPTED_TRANSACTION("54"),
-	/** Transaction amounts could not be converted code */
+	/**
+	 * Transaction amounts could not be converted code
+	 */
 	ERROR_CONVERTING_TRANSACTION_AMOUNTS("55"),
-	/** Transaction transmission is pending code */
+	/**
+	 * Transaction transmission is pending code
+	 */
 	PENDING_TRANSACTION_TRANSMISSION("9998"),
-	/** Bad response from the payment network code */
+	/**
+	 * Bad response from the payment network code
+	 */
 	PAYMENT_NETWORK_BAD_RESPONSE("100"),
-	/** Connection failure with the payment network code */
+	/**
+	 * Connection failure with the payment network code
+	 */
 	PAYMENT_NETWORK_NO_CONNECTION("101"),
-	/** Payment network not sending response code */
+	/**
+	 * Payment network not sending response code
+	 */
 	PAYMENT_NETWORK_NO_RESPONSE("102"),
 
 	//Clinic
-	/** Fix was not required code */
+	/**
+	 * Fix was not required code
+	 */
 	FIX_NOT_REQUIRED("10000"),
-	/** Transaction was automatically fixed  and could make a reversal code */
+	/**
+	 * Transaction was automatically fixed  and could make a reversal code
+	 */
 	AUTOMATICALLY_FIXED_AND_SUCCESS_REVERSAL("10001"),
-	/** Transaction was automatically fixed  and couldn't make a reversal code */
+	/**
+	 * Transaction was automatically fixed  and couldn't make a reversal code
+	 */
 	AUTOMATICALLY_FIXED_AND_UNSUCCESS_REVERSAL("10002"),
-	/** Transaction can't be automatically fixed code */
+	/**
+	 * Transaction can't be automatically fixed code
+	 */
 	AUTOMATIC_FIXED_NOT_SUPPORTED("10003"),
-	/** Transaction was not fixed due to an error state code */
+	/**
+	 * Transaction was not fixed due to an error state code
+	 */
 	NOT_FIXED_FOR_ERROR_STATE("10004"),
-	/** Transaction could not be fixed and reversed code */
+	/**
+	 * Transaction could not be fixed and reversed code
+	 */
 	ERROR_FIXING_AND_REVERSING("10005"),
-	/** Transaction was not fixed due to incomplete data code */
+	/**
+	 * Transaction was not fixed due to incomplete data code
+	 */
 	ERROR_FIXING_INCOMPLETE_DATA("10006"),
-	/** Awaiting PSE confirmation **/
+	/**
+	 * Awaiting PSE confirmation
+	 **/
 	PENDING_AWAITING_PSE_CONFIRMATION("28"),
-	/** **/
+	/**
+	 *
+	 **/
 	INVALID_RESPONSE_PARTIAL_APPROVAL("10007"),
 
-	/** The transaction was declined by test mode.*/
+	/**
+	 * The transaction was declined by test mode.
+	 */
 	DECLINED_TEST_MODE_NOT_ALLOWED("40"),
-	/** **/
+	/**
+	 *
+	 **/
 	ERROR_CONVERTING_DEPOSIT_AMOUNTS("56"),
-	/** The transaction is related to a bank account with an error during its activation process */
+	/**
+	 * The transaction is related to a bank account with an error during its activation process
+	 */
 	BANK_ACCOUNT_ACTIVATION_ERROR("31"),
-	/** The bank account is not authorized for automatic debit. */
+	/**
+	 * The bank account is not authorized for automatic debit.
+	 */
 	BANK_ACCOUNT_NOT_AUTHORIZED_FOR_AUTOMATIC_DEBIT("32"),
-	/** The bank account agency value is invalid. */
+	/**
+	 * The bank account agency value is invalid.
+	 */
 	INVALID_AGENCY_BANK_ACCOUNT("33"),
-	/** The bank account is invalid. */
+	/**
+	 * The bank account is invalid.
+	 */
 	INVALID_BANK_ACCOUNT("34"),
-	/** The bank is invalid. */
+	/**
+	 * The bank is invalid.
+	 */
 	INVALID_BANK("35"),
-	/** The transaction was sent to answer questionnaire. */
+	/**
+	 * The transaction was sent to answer questionnaire.
+	 */
 	PENDING_ANSWER_MAF_QUESTIONNAIRE("16"),
-	/** The transaction is pending for payment in entity*/
+	/**
+	 * The transaction is pending for payment in entity
+	 */
 	PENDING_PAYMENT_IN_ENTITY("25"),
-	/** The transaction is pending for payment in bank */
+	/**
+	 * The transaction is pending for payment in bank
+	 */
 	PENDING_PAYMENT_IN_BANK("26"),
-	/** The transaction is pending to sent tot financial entity*/
+	/**
+	 * The transaction is pending to sent tot financial entity
+	 */
 	PENDING_SENT_TO_FINANCIAL_ENTITY("29"),
-	/** The transaction is pending for notifying entity*/
+	/**
+	 * The transaction is pending for notifying entity
+	 */
 	PENDING_NOTIFYING_ENTITY("30"),
 
-	/** The transaction cancelled by payer before being processed */
+	/**
+	 * The transaction cancelled by payer before being processed
+	 */
 	CANCELLED_TRANSACTION_PAYER("10008"),
-	/** The transaction cancelled by merchant before being processed */
-	CANCELLED_TRANSACTION_MERCHANT("10009");
+	/**
+	 * The transaction cancelled by merchant before being processed
+	 */
+	CANCELLED_TRANSACTION_MERCHANT("10009"),
+	/**
+	 * The transaction was abandoned by client at gateway The transaction was abandoned (Cash)
+	 */
+	ABANDONED_TRANSACTION("19"),
+
+	/**
+	 * The first refund transaction of dispersion was Approved but is necessary execute a second refund transaction by clinic
+	 * <ol>
+	 * 	<li>First transaction = Airline values</li>
+	 * 	<li>Second transaction = Agency values</li>
+	 * </ol>
+	 */
+	APPROVED_REFUND_DISPERSION("1"),
+
+	/**
+	 * The code for ACH BANCOLOMBIA process
+	 */
+	INVALID_FIELD_STRUCTURE("10010");
 
 	/**
 	 * The transaction response code.
@@ -155,6 +266,7 @@ public enum TransactionResponseCode {
 	 * @param code the transaction response code.
 	 */
 	private TransactionResponseCode(String code) {
+
 		this.code = code;
 	}
 
@@ -164,6 +276,7 @@ public enum TransactionResponseCode {
 	 * @return the transaction response code.
 	 */
 	public String getCode() {
+
 		return code;
 	}
 

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -37,7 +37,7 @@ public enum TransactionResponseCode {
 	 */
 	ANTIFRAUD_REJECTED("23"),
 	/**
-	 * Transaction rejected due to suspected fraud at the financial institution
+	 * Transaction rejected on suspicion of fraud at the financial institution
 	 */
 	BANK_FRAUD_REJECTED("10011"),
 	/**
@@ -229,20 +229,21 @@ public enum TransactionResponseCode {
 	PENDING_NOTIFYING_ENTITY("30"),
 
 	/**
-	 * The transaction cancelled by payer before being processed
+	 * The transaction was cancelled by the payer before being processed
 	 */
 	CANCELLED_TRANSACTION_PAYER("10008"),
 	/**
-	 * The transaction cancelled by merchant before being processed
+	 * The transaction was cancelled by the merchant before being processed
 	 */
 	CANCELLED_TRANSACTION_MERCHANT("10009"),
 	/**
-	 * The transaction was abandoned by client at gateway The transaction was abandoned (Cash)
+	 * The transaction was abandoned by the client at gateway
+	 * The transaction was abandoned (Cash)
 	 */
 	ABANDONED_TRANSACTION("19"),
 
 	/**
-	 * The first refund transaction of dispersion was Approved but is necessary execute a second refund transaction by clinic
+	 * The first refund transaction of dispersion was Approved but is necessary to execute a second refund transaction by a clinic
 	 * <ol>
 	 * 	<li>First transaction = Airline values</li>
 	 * 	<li>Second transaction = Agency values</li>

--- a/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
+++ b/src/main/java/com/payu/sdk/model/TransactionResponseCode.java
@@ -41,6 +41,8 @@ public enum TransactionResponseCode {
 	ENTITY_DECLINED("5"),
 	/** Transaction rejected by anti fraud system code */
 	ANTIFRAUD_REJECTED("23"),
+	/** Transaction rejected due to suspected fraud at the financial institution */
+	BANK_FRAUD_REJECTED("10011"),
 	/** Transaction review pending code */
 	PENDING_TRANSACTION_REVIEW("15"),
 	/** Transaction expired code */

--- a/src/main/resources/release_notes/1.3.6.txt
+++ b/src/main/resources/release_notes/1.3.6.txt
@@ -1,6 +1,6 @@
 2020-09-24
 ----------
-Actualización de códigos de respuesta en la enumeración TransactionResponseCode
+Adición de códigos de respuesta en la enumeración TransactionResponseCode
 
 BANK_FRAUD_REJECTION
 
@@ -9,6 +9,9 @@ ABANDONED_TRANSACTION
 APPROVED_REFUND_DISPERSION
 
 INVALID_FIELD_STRUCTURE
+
+Para la integración continua con travis se actualizó el openjdk del 7 al 9.
+Se agrego la dependencia javax.xml.bind con un scope de test para arreglar errores en la integración
 
 Issue:
 https://pagosonline.jira.com/browse/S2P-381

--- a/src/main/resources/release_notes/1.3.6.txt
+++ b/src/main/resources/release_notes/1.3.6.txt
@@ -1,0 +1,14 @@
+2020-09-24
+----------
+Actualización de códigos de respuesta en la enumeración TransactionResponseCode
+
+BANK_FRAUD_REJECTION
+
+ABANDONED_TRANSACTION
+
+APPROVED_REFUND_DISPERSION
+
+INVALID_FIELD_STRUCTURE
+
+Issue:
+https://pagosonline.jira.com/browse/S2P-381


### PR DESCRIPTION
Adding response codes in TransactionResponseCode enumeration

BANK_FRAUD_REJECTION

ABANDONED_TRANSACTION

APPROVED_REFUND_DISPERSION

INVALID_FIELD_STRUCTURE

For continuous integration with travis, openjdk was updated from 7 to 9.

The dependency javax.xml.bind was added with a test scope to fix errors in the integration

